### PR TITLE
Answer Selection

### DIFF
--- a/src/components/QuizView/QuizAnswers.js
+++ b/src/components/QuizView/QuizAnswers.js
@@ -5,16 +5,25 @@ const useStyles = makeStyles(() => ({
   answer: {
     width: "100%",
     height: "100%",
+    "&:hover": {
+      backgroundColor: "transparent",
+    },
   },
   correct: {
     width: "100%",
     height: "100%",
     backgroundColor: "#C8FFF4",
+    "&:hover": {
+      backgroundColor: "#C8FFF4",
+    },
   },
   incorrect: {
     width: "100%",
     height: "100%",
     backgroundColor: "#F5DBDB",
+    "&:hover": {
+      backgroundColor: "#F5DBDB",
+    },
   },
 }));
 

--- a/src/components/QuizView/QuizAnswers.js
+++ b/src/components/QuizView/QuizAnswers.js
@@ -31,37 +31,29 @@ function QuizAnswers({ answers }) {
   const classes = useStyles();
   const [selectedAnswer, setSelectedAnswer] = useState(null);
 
-  const renderAnswerButton = (answer) => {
-    if (selectedAnswer && selectedAnswer.value === answer.value) {
-      return (
-        <Button
-          className={answer.isCorrect ? classes.correct : classes.incorrect}
-          variant="contained"
-          disableElevation
-          onClick={() => setSelectedAnswer(answer)}
-        >
-          {answer.value}
-        </Button>
-      );
-    } else {
-      return (
-        <Button
-          className={classes.answer}
-          variant="outlined"
-          color="secondary"
-          onClick={() => setSelectedAnswer(answer)}
-        >
-          {answer.value}
-        </Button>
-      );
-    }
-  };
-
   return (
     <Grid container spacing={2}>
       {answers.map((answer) => (
         <Grid item xs={12} sm={6} key={answer.value}>
-          {renderAnswerButton(answer)}
+          {selectedAnswer && selectedAnswer.value === answer.value ? (
+            <Button
+              className={answer.isCorrect ? classes.correct : classes.incorrect}
+              variant="contained"
+              disableElevation
+              onClick={() => setSelectedAnswer(answer)}
+            >
+              {answer.value}
+            </Button>
+          ) : (
+            <Button
+              className={classes.answer}
+              variant="outlined"
+              color="secondary"
+              onClick={() => setSelectedAnswer(answer)}
+            >
+              {answer.value}
+            </Button>
+          )}
         </Grid>
       ))}
     </Grid>

--- a/src/components/QuizView/QuizAnswers.js
+++ b/src/components/QuizView/QuizAnswers.js
@@ -30,9 +30,7 @@ function QuizAnswers({ answers }) {
             className={classes.correct}
             variant="contained"
             disableElevation
-            onClick={() => {
-              setSelectedAnswer(answer);
-            }}
+            onClick={() => setSelectedAnswer(answer)}
           >
             {answer.value}
           </Button>
@@ -43,9 +41,7 @@ function QuizAnswers({ answers }) {
           className={classes.incorrect}
           variant="contained"
           disableElevation
-          onClick={() => {
-            setSelectedAnswer(answer);
-          }}
+          onClick={() => setSelectedAnswer(answer)}
         >
           {answer.value}
         </Button>
@@ -56,9 +52,7 @@ function QuizAnswers({ answers }) {
           className={classes.answer}
           variant="outlined"
           color="secondary"
-          onClick={() => {
-            setSelectedAnswer(answer);
-          }}
+          onClick={() => setSelectedAnswer(answer)}
         >
           {answer.value}
         </Button>

--- a/src/components/QuizView/QuizAnswers.js
+++ b/src/components/QuizView/QuizAnswers.js
@@ -33,21 +33,9 @@ function QuizAnswers({ answers }) {
 
   const renderAnswerButton = (answer) => {
     if (selectedAnswer && selectedAnswer.value === answer.value) {
-      if (answer.isCorrect) {
-        return (
-          <Button
-            className={classes.correct}
-            variant="contained"
-            disableElevation
-            onClick={() => setSelectedAnswer(answer)}
-          >
-            {answer.value}
-          </Button>
-        );
-      }
       return (
         <Button
-          className={classes.incorrect}
+          className={answer.isCorrect ? classes.correct : classes.incorrect}
           variant="contained"
           disableElevation
           onClick={() => setSelectedAnswer(answer)}

--- a/src/components/QuizView/QuizAnswers.js
+++ b/src/components/QuizView/QuizAnswers.js
@@ -1,23 +1,76 @@
+import { useState } from "react";
 import { Button, Grid, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles(() => ({
-  answer: { width: "100%", height: "100%" },
+  answer: {
+    width: "100%",
+    height: "100%",
+  },
+  correct: {
+    width: "100%",
+    height: "100%",
+    backgroundColor: "#C8FFF4",
+  },
+  incorrect: {
+    width: "100%",
+    height: "100%",
+    backgroundColor: "#F5DBDB",
+  },
 }));
 
 function QuizAnswers({ answers }) {
   const classes = useStyles();
+  const [selectedAnswer, setSelectedAnswer] = useState(null);
+
+  const renderAnswerButton = (answer) => {
+    if (selectedAnswer && selectedAnswer.value === answer.value) {
+      if (answer.isCorrect) {
+        return (
+          <Button
+            className={classes.correct}
+            variant="contained"
+            disableElevation
+            onClick={() => {
+              setSelectedAnswer(answer);
+            }}
+          >
+            {answer.value}
+          </Button>
+        );
+      }
+      return (
+        <Button
+          className={classes.incorrect}
+          variant="contained"
+          disableElevation
+          onClick={() => {
+            setSelectedAnswer(answer);
+          }}
+        >
+          {answer.value}
+        </Button>
+      );
+    } else {
+      return (
+        <Button
+          className={classes.answer}
+          variant="outlined"
+          color="secondary"
+          onClick={() => {
+            setSelectedAnswer(answer);
+          }}
+        >
+          {answer.value}
+        </Button>
+      );
+    }
+  };
 
   return (
     <Grid container spacing={2}>
-      {answers.map((value) => (
-        <Grid item xs={12} sm={6} key={value}>
-          <Button
-            className={classes.answer}
-            variant="outlined"
-            color="secondary"
-          >
-            {value}
-          </Button>
+      {answers.map((answer) => (
+        <Grid item xs={12} sm={6} key={answer.value}>
+          {renderAnswerButton(answer)}
         </Grid>
       ))}
     </Grid>

--- a/src/components/QuizView/QuizView.js
+++ b/src/components/QuizView/QuizView.js
@@ -39,12 +39,19 @@ function QuizView() {
       (currentIndex) => (currentIndex - 1 + questions.length) % questions.length
     );
 
-  const answersList = shuffle([
-    ...question.answersJSON.incorrectAnswers,
-    question.answersJSON.correctAnswer,
-  ]);
-
-  console.log(answersList);
+  const makeAnswersList = () => {
+    return shuffle(
+      [
+        question.answersJSON.correctAnswer,
+        ...question.answersJSON.incorrectAnswers,
+      ].map((answer) => {
+        return {
+          value: answer,
+          isCorrect: answer === question.answersJSON.correctAnswer,
+        };
+      })
+    );
+  };
 
   return (
     <Container maxWidth="md">
@@ -54,7 +61,7 @@ function QuizView() {
         totalQuestions={questions.length}
       />
       <QuizCard question={question.questionText} />
-      <QuizAnswers answers={answersList} />
+      <QuizAnswers answers={makeAnswersList()} />
       <QuizNav onClickNext={onClickNext} onClickPrevious={onClickPrevious} />
     </Container>
   );


### PR DESCRIPTION
The styling could use a little clean up, but this highlights the selected answer in green or red based on whether or not it is correct. Had some weirdness around getting the answers list to not reshuffle on update, so I lifted the answer mapping to the parent view.

closes #13 

![Screen Shot 2021-03-05 at 3 08 46 PM](https://user-images.githubusercontent.com/12776258/110173772-b9d8fe80-7dc4-11eb-81cd-fb12437431e0.png)
![Screen Shot 2021-03-05 at 3 08 52 PM](https://user-images.githubusercontent.com/12776258/110173775-ba719500-7dc4-11eb-842c-4a842343ad2a.png)

